### PR TITLE
fix: doesn't respect border-radius in Safari #13

### DIFF
--- a/src/utils/createContainerElement.ts
+++ b/src/utils/createContainerElement.ts
@@ -18,5 +18,9 @@ export const createContainer = ({
   waveContainer.style.borderRadius = `${borderTopLeftRadius} ${borderTopRightRadius} ${borderBottomRightRadius} ${borderBottomLeftRadius}`
   waveContainer.style.overflow = 'hidden'
   waveContainer.style.pointerEvents = 'none'
+
+  // Meet Safari, the new IE 💩
+  waveContainer.style.webkitMaskImage = '-webkit-radial-gradient(white, black)'
+
   return waveContainer
 }


### PR DESCRIPTION
Solution found here: https://stackoverflow.com/questions/49066011/overflow-hidden-with-border-radius-not-working-on-safari

```js
  // Meet Safari, the new IE 💩
  waveContainer.style.webkitMaskImage = '-webkit-radial-gradient(white, black)'
```

Fixes #13