### PR TITLE
fix: remove `bridge` option from Nuxt module's compatibility meta

### DIFF
--- a/nuxt/index.ts
+++ b/nuxt/index.ts
@@ -9,7 +9,6 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'vWave',
     compatibility: {
       nuxt: '>=3.0.0',
-      bridge: true,
     },
   },
   defaults: {


### PR DESCRIPTION
resolves https://github.com/justintaddei/v-wave/issues/873